### PR TITLE
makefile/pro: link boost_chrono

### DIFF
--- a/gostcoin-qt.pro
+++ b/gostcoin-qt.pro
@@ -454,7 +454,11 @@ LIBS += $$join(BOOST_LIB_PATH,,-L,) $$join(BDB_LIB_PATH,,-L,) $$join(OPENSSL_LIB
 LIBS += -lssl -lcrypto -ldb_cxx$$BDB_LIB_SUFFIX -lz
 # -lgdi32 has to happen after -lcrypto (see  #681)
 win32:LIBS += -lws2_32 -lshlwapi -lmswsock -lole32 -loleaut32 -luuid -lgdi32
-LIBS += -lboost_system$$BOOST_LIB_SUFFIX -lboost_filesystem$$BOOST_LIB_SUFFIX -lboost_program_options$$BOOST_LIB_SUFFIX -lboost_thread$$BOOST_THREAD_LIB_SUFFIX
+LIBS += -lboost_system$$BOOST_LIB_SUFFIX \
+	-lboost_filesystem$$BOOST_LIB_SUFFIX \
+	-lboost_program_options$$BOOST_LIB_SUFFIX \
+	-lboost_thread$$BOOST_THREAD_LIB_SUFFIX \
+	-lboost_chrono$$BOOST_THREAD_LIB_SUFFIX
 
 win32|macx {
     LIBS += -lboost_chrono$$BOOST_LIB_SUFFIX

--- a/src/makefile.bsd
+++ b/src/makefile.bsd
@@ -38,6 +38,7 @@ LIBS += \
    -l boost_filesystem$(BOOST_LIB_SUFFIX) \
    -l boost_program_options$(BOOST_LIB_SUFFIX) \
    -l boost_thread$(BOOST_LIB_SUFFIX) \
+   -l boost_chrono$(BOOST_LIB_SUFFIX) \
    -l db_cxx$(BDB_LIB_SUFFIX) \
    -l ssl \
    -l crypto

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -34,6 +34,7 @@ LIBS += \
 	-lboost_filesystem$(BOOST_LIB_SUFFIX) \
 	-lboost_program_options$(BOOST_LIB_SUFFIX) \
 	-lboost_thread$(BOOST_LIB_SUFFIX) \
+	-lboost_chrono$(BOOST_LIB_SUFFIX) \
 	-ldb_cxx$(BDB_LIB_SUFFIX) \
 	-lssl \
 	-lcrypto


### PR DESCRIPTION
Fixes build failure due to undefined symbol (tested on Arch Linux).