### PR TITLE
Fixes out-of-bouns

### DIFF
--- a/src/script.h
+++ b/src/script.h
@@ -642,12 +642,12 @@ public:
     void Serialize(Stream &s, int nType, int nVersion) const {
         std::vector<unsigned char> compr;
         if (Compress(compr)) {
-            s << CFlatData(&compr[0], &compr[compr.size()]);
+            s << CFlatData(compr.data(), compr.data() + compr.size());
             return;
         }
         unsigned int nSize = script.size() + nSpecialScripts;
         s << VARINT(nSize);
-        s << CFlatData(&script[0], &script[script.size()]);
+        s << CFlatData(script.data(), script.data() + script.size());
     }
 
     template<typename Stream>
@@ -656,13 +656,13 @@ public:
         s >> VARINT(nSize);
         if (nSize < nSpecialScripts) {
             std::vector<unsigned char> vch(GetSpecialSize(nSize), 0x00);
-            s >> REF(CFlatData(&vch[0], &vch[vch.size()]));
+            s >> REF(CFlatData(vch.data(), vch.data() + vch.size()));
             Decompress(nSize, vch);
             return;
         }
         nSize -= nSpecialScripts;
         script.resize(nSize);
-        s >> REF(CFlatData(&script[0], &script[script.size()]));
+        s >> REF(CFlatData(script.data(), script.data() + script.size()));
     }
 };
 


### PR DESCRIPTION
Заменил получение границ массива с `&compr[0], &compr[compr.size()]` на более современный и надежный вариант `compr.data(), compr.data() + compr.size()`. В частности, он не будет падать при векторе размера 0, когда `compr[0]` упал бы с ошибкой.